### PR TITLE
Support for proxied IP detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 composer.lock
 tests/_output/*
+/nbproject

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0"
+    "php": ">=5.5.0",
+    "vectorface/whip": "*"
   },
   "require-dev": {
     "codeception/base": "*"

--- a/src/Foowie/IP/DI/IPExtension.php
+++ b/src/Foowie/IP/DI/IPExtension.php
@@ -4,18 +4,31 @@ namespace Foowie\IP\DI;
 
 use Kdyby\Doctrine\DI\IDatabaseTypeProvider;
 use Nette\DI\CompilerExtension;
+use Nette\DI\ContainerBuilder;
+use Nette\DI\ServiceDefinition;
+use Vectorface\Whip\IpRange\IpWhitelist;
 
 /**
  * @author Daniel Robenek <daniel.robenek@me.com>
  */
 class IPExtension extends CompilerExtension implements IDatabaseTypeProvider {
 
+	/** @var array */
+	public $defaults = [
+		'proxy' => [
+			'enabled' => false,
+			'filter' => [ //all addresses by default
+				'IPv4' => '0.0.0.0/0',
+				'IPv6' => '::/0',
+			],
+		]
+	];
+
 	public function loadConfiguration() {
 		$builder = $this->getContainerBuilder();
 
 		if(class_exists('Foowie\CloudflareDetection\CloudflareDetector')) {
-			$fallback = $builder->addDefinition($this->prefix('fallbackIpFactory'))
-				->setClass('Foowie\IP\RemoteIPFactory\ServerRemoteAddrIPFactory')
+			$fallback = $this->getDefaultFactory($builder, $this->prefix('fallbackIpFactory'))
 				->setAutowired(false);
 			$cloudflareDetector = $builder->addDefinition($this->prefix('cloudflareDetector'))
 				->setClass('Foowie\CloudflareDetection\CloudflareDetector')
@@ -23,9 +36,28 @@ class IPExtension extends CompilerExtension implements IDatabaseTypeProvider {
 			$builder->addDefinition($this->prefix('ipFactory'))
 				->setClass('Foowie\IP\RemoteIPFactory\CloudflareIPFactory', [$cloudflareDetector, $fallback]);
 		} else {
-			$builder->addDefinition($this->prefix('ipFactory'))
-				->setClass('Foowie\IP\RemoteIPFactory\ServerRemoteAddrIPFactory');
+			$this->getDefaultFactory($builder, $this->prefix('ipFactory'));
 		}
+	}
+
+	/**
+	 * Creates Foowie\IP\RemoteIPFactory\ServerRemoteAddrIPFactory service
+	 * @param ContainerBuilder $builder
+	 * @param string $prefix
+	 * @return ServiceDefinition
+	 */
+	protected function getDefaultFactory(ContainerBuilder $builder, $prefix) {
+		$config = $this->getConfig($this->defaults);
+		$whitelist = null;
+		if ((bool)$config['proxy']['enabled']) {
+			$whitelist = new IpWhitelist([
+				IpWhitelist::IPV4 => (array)$config['proxy']['filter']['IPv4'],
+				IpWhitelist::IPV6 => (array)$config['proxy']['filter']['IPv6'],
+			]);
+		}
+		
+		return $builder->addDefinition($prefix)
+			->setClass('Foowie\IP\RemoteIPFactory\ServerRemoteAddrIPFactory', [$whitelist]);
 	}
 
 	/**

--- a/src/Foowie/IP/RemoteIPFactory/ServerRemoteAddrIPFactory.php
+++ b/src/Foowie/IP/RemoteIPFactory/ServerRemoteAddrIPFactory.php
@@ -1,22 +1,56 @@
 <?php
 
 namespace Foowie\IP\RemoteIPFactory;
+
 use Foowie\IP\IP;
+use Vectorface\Whip\IpRange\IpWhitelist;
+use Vectorface\Whip\Request\RequestAdapter;
+use Vectorface\Whip\Request\SuperglobalRequestAdapter;
 
 /**
  * @author Daniel Robenek <daniel.robenek@me.com>
  */
 class ServerRemoteAddrIPFactory implements IPFactory {
 
+	/** @var IpWhitelist */
+	protected $proxyIpWhitelist;
+
+	/** @var RequestAdapter */
+	protected $requestAdapter;
+
+	public function __construct(IpWhitelist $proxyIpWhitelist = null, RequestAdapter $requestAdapter = null) {
+		$this->proxyIpWhitelist = $proxyIpWhitelist;
+		$this->requestAdapter = $requestAdapter === null ? new SuperglobalRequestAdapter($_SERVER) : $requestAdapter;
+	}
+
 	/**
 	 * @return IP
 	 * @throws NoRemoteIPException
 	 */
 	public function createRemoteIP() {
-		if(!isset($_SERVER["REMOTE_ADDR"])) {
+		$remoteAddress = $this->requestAdapter->getRemoteAddr();
+		if($remoteAddress === null) {
 			throw new NoRemoteIPException("Can't detect remote IP address!");
 		}
-		return new IP($_SERVER["REMOTE_ADDR"]);
+		$proxiedIp = $this->getProxiedIp($remoteAddress);
+		return $proxiedIp === null ? new IP($remoteAddress) : $proxiedIp;
+	}
+
+	/**
+	 * @param string|null $remoteAddress
+	 * @return IP
+	 */
+	protected function getProxiedIp($remoteAddress) {
+		if ($this->proxyIpWhitelist !== null && $this->proxyIpWhitelist->isIpWhitelisted($remoteAddress)) {
+			$headers = $this->requestAdapter->getHeaders();
+			if (isset($headers['x-forwarded-for'])) {
+				$ipAddresses = explode(',', str_replace(' ', '', $headers['x-forwarded-for']));
+				if (@\inet_pton($ipAddresses[0]) !== false) {
+					return new IP($ipAddresses[0]);
+				}
+			}
+		}
+		return null;
 	}
 
 }


### PR DESCRIPTION
Get real client's IP address from standard `x-forwarded-for` header if `REMOTE_ADDRESS` "proxied" by other services with `REMOTE_ADDRESS` filtering support.